### PR TITLE
fix: fixes substitution issue with classpaths

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -10,9 +10,9 @@ dependencies:
   org.slf4j:slf4j-simple: "2.0.17"
 
 actions:
-  clean: ".{/}mvnw clean"
-  build: ".{/}mvnw spotless:apply package -DskipTests"
-  run: "{./target/binary/bin/jpm}"
-  test: ".{/}mvnw test"
+  clean: "./mvnw clean"
+  build: "./mvnw spotless:apply package -DskipTests"
+  run: "./target/binary/bin/jpm"
+  test: "./mvnw test"
   buildj: "javac -cp {{deps}} -d classes --source-path src/main/java src/main/java/org/codejive/jpm/Main.java"
   runj: "java -cp classes:{{deps}} org.codejive.jpm.Main"

--- a/src/test/java/org/codejive/jpm/util/ScriptUtilsTest.java
+++ b/src/test/java/org/codejive/jpm/util/ScriptUtilsTest.java
@@ -257,4 +257,12 @@ class ScriptUtilsTest {
             assertThat(argsFiles.files.get(1)).hasContent(expectedContents2);
         }
     }
+
+    @Test
+    void testProcessCommandWithInvalidClasspath() {
+        String command = "./mvnw spotless:apply package -DskipTests";
+        String result = ScriptUtils.suggestSubstitutions(command);
+        // Substitutions should not have treated spottless:apply as a classpath
+        assertThat(result).isEqualTo("{./mvnw} spotless:apply package -DskipTests");
+    }
 }


### PR DESCRIPTION
Some normal options like "plugin:apply" were taken to be a classpath and where marked for substitution. We now properly ignore them.

Fixes #68